### PR TITLE
remove annotation section from API documentation

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -20,7 +20,6 @@ includes:
   - api_notice
   - api_account
   - api_action
-  - api_annotation
   - api_feedback
   - api_metric
   - api_pngspan


### PR DESCRIPTION
Easy one; just removing annotation from API documentation.