### PR TITLE
[EEN-7475] Video/Bundle/TimeLapse sub-section added to Images and Videos [Initiate Video Download]

### DIFF
--- a/source/includes/_api_asset.md
+++ b/source/includes/_api_asset.md
@@ -211,6 +211,71 @@ HTTP Status Code | Description
 200	| Request succeeded
 
 <!--===================================================================-->
+## Initiate Video Download
+<!--===================================================================-->
+
+Initiate the download of a Bundle, TimeLapse or Video in the requested `'download_type'` and `'video_format'` based on the specified timestamps. Returns the download id
+
+### Download types:
+
+  - **Video** *(Returns an MP4 trans-coded video)*
+  - **Bundle** *(Returns a ZIP Archive file with individual MP4 videos and a TimeLapse video)*
+  - **TimeLapse** *(Returns a TimeLapse trans-coded video)*
+
+### Video formats:
+
+  - **MP4**
+
+> Request
+
+```shell
+curl -X PUT https://c001.eagleeyenetworks.com/g/video_download -d '{"camera_id":"[CAMERA_ID]", "start_timestamp":"[START_TIMESTAMP]", "end_timestamp":"[END_TIMESTAMP]", "download_type":"[DOWNLOAD_TYPE]"}' -H "content-type: application/json" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -v
+```
+
+### HTTP Request
+
+`PUT https://c001.eagleeyenetworks.com/g/video_download`
+
+Parameter              | Data Type | Description | Is Required
+---------              | --------- | ----------- | -----------
+**camera_id**          | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> | true
+**start_timestamp**    | string    | Start timestamp in EEN format: YYYYMMDDHHMMSS.NNN | true
+**end_timestamp**      | string    | End timestamp in EEN format: YYYYMMDDHHMMSS.NNN | true
+is_timestamp_enabled   | boolean   | Indicates whether a timestamp should be embedded into the video (1) or not (0)
+timezone               | string    | Timezone which should be embedded into the video
+download_type          | string    | Download type to create. Defaults to `'Video'` <br><br>enum: Video, Bundle, TimeLapse
+video_format           | string    | Video format to use. Defaults to `'mp4'` (currently only MP4 is available)
+video_description      | string    | Video description
+playback_speed         | int       | Video playback speed
+notes                  | string    | Notes
+is_watermark_enabled   | boolean   | ***(Future Feature)*** Indicates whether a watermark should be embedded into the video (1) or not (0)
+is_camera_name_enabled | boolean   | ***(Future Feature)*** Indicates whether the camera name should be embedded into the video (1) or not (0)
+
+> Response
+
+```shell
+{
+    "id": "12c1fa4e-f155-11e7-8586-02420a807306"
+}
+```
+
+### HTTP Response
+
+Parameter | Data Type | Description
+--------- | --------- | -----------
+id        | string    | Download ID
+
+### Error Status Codes
+
+HTTP Status Code | Description
+---------------- | -----------
+400	| Unexpected or non-identifiable arguments are supplied
+401	| Unauthorized due to invalid session cookie
+403	| Forbidden due to the user missing the necessary privileges
+404	| Download unavailable / missing
+202	| Request succeeded
+
+<!--===================================================================-->
 ## Prefetch Image
 <!--===================================================================-->
 


### PR DESCRIPTION
Video/Bundle/TimeLapse sub-section added to Images and Videos [Initiate Video Download]

The section will likely be updated with the implementation of the following changes, which seem necessary:

Change 1 download types (in videobank/core/views/__init__.py):



    def StartVideoDownload(user,
                           account_id,
                           start_timestamp,
                           end_timestamp,
                           camera_id=None,
                           request=None,
                           is_watermark_enabled=False,
                           is_camera_name_enabled=False,
                           is_timestamp_enabled=True,
                           video_format="mp4",
                           video_description=None,
                           timezone=None,
                           playback_speed=1,
                           download_type="Video",               <-----  HERE lowercase
                           notes=None):

...


    if download_type not in ['Bundle', 'Video', 'TimeLapse']:   <-----  HERE lowercase


The lowercase implementation will involve an update several test scripts and related files.

Change 2 video formats (in videobank/core/views/__init__.py):

    def StartVideoDownload

...

    video_formats = ['flv', 'mp4', ]                            <-----  HERE remove flv, download video with flv specified yields a 404