### PR TITLE
[EEN-7475] and [API-289] Video/Bundle/TimeLapse sub-section added to Images and Videos [Initiate Video Download]

### DIFF
--- a/source/includes/_api_asset.md
+++ b/source/includes/_api_asset.md
@@ -211,6 +211,71 @@ HTTP Status Code | Description
 200	| Request succeeded
 
 <!--===================================================================-->
+## Initiate Video Download
+<!--===================================================================-->
+
+Initiate the download of a Bundle, TimeLapse or Video in the requested `'download_type'` and `'video_format'` based on the specified timestamps. Returns the download id
+
+### Download types:
+
+  - **Video** *(Returns an MP4 trans-coded video)*
+  - **Bundle** *(Returns a ZIP Archive file with individual MP4 videos and a TimeLapse video)*
+  - **TimeLapse** *(Returns a TimeLapse trans-coded video)*
+
+### Video formats:
+
+  - **MP4**
+
+> Request
+
+```shell
+curl -X PUT https://c001.eagleeyenetworks.com/g/video_download -d '{"camera_id":"[CAMERA_ID]", "start_timestamp":"[START_TIMESTAMP]", "end_timestamp":"[END_TIMESTAMP]", "download_type":"[DOWNLOAD_TYPE]"}' -H "content-type: application/json" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -v
+```
+
+### HTTP Request
+
+`PUT https://c001.eagleeyenetworks.com/g/video_download`
+
+Parameter              | Data Type | Description | Is Required
+---------              | --------- | ----------- | -----------
+**camera_id**          | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> | true
+**start_timestamp**    | string    | Start timestamp in EEN format: YYYYMMDDHHMMSS.NNN | true
+**end_timestamp**      | string    | End timestamp in EEN format: YYYYMMDDHHMMSS.NNN | true
+is_timestamp_enabled   | boolean   | Indicates whether a timestamp should be embedded into the video (1) or not (0)
+timezone               | string    | Timezone which should be embedded into the video
+download_type          | string    | Download type to create. Defaults to `'Video'` <br><br>enum: Video, Bundle, TimeLapse
+video_format           | string    | Video format to use. Defaults to `'mp4'` (currently only MP4 is available)
+video_description      | string    | Video description
+playback_speed         | int       | Video playback speed
+notes                  | string    | Notes
+is_watermark_enabled   | boolean   | ***(Future Feature)*** Indicates whether a watermark should be embedded into the video (1) or not (0)
+is_camera_name_enabled | boolean   | ***(Future Feature)*** Indicates whether the camera name should be embedded into the video (1) or not (0)
+
+> Response
+
+```shell
+{
+    "id": "12c1fa4e-f155-11e7-8586-02420a807306"
+}
+```
+
+### HTTP Response
+
+Parameter | Data Type | Description
+--------- | --------- | -----------
+id        | string    | Download ID
+
+### Error Status Codes
+
+HTTP Status Code | Description
+---------------- | -----------
+400	| Unexpected or non-identifiable arguments are supplied
+401	| Unauthorized due to invalid session cookie
+403	| Forbidden due to the user missing the necessary privileges
+404	| Download unavailable / missing
+202	| Request succeeded
+
+<!--===================================================================-->
 ## Prefetch Image
 <!--===================================================================-->
 

--- a/source/includes/_api_asset.md
+++ b/source/includes/_api_asset.md
@@ -218,9 +218,9 @@ Initiate the download of a Bundle, TimeLapse or Video in the requested `'downloa
 
 ### Download types:
 
-  - **Video** *(Returns an MP4 trans-coded video)*
-  - **Bundle** *(Returns a ZIP Archive file with individual MP4 videos and a TimeLapse video)*
-  - **TimeLapse** *(Returns a TimeLapse trans-coded video)*
+  - **Video:** Returns an MP4 trans-coded video
+  - **Bundle:** Returns a ZIP Archive file with individual MP4 videos and a TimeLapse video
+  - **TimeLapse:** Returns a TimeLapse trans-coded video
 
 ### Video formats:
 
@@ -243,7 +243,7 @@ Parameter              | Data Type | Description | Is Required
 **end_timestamp**      | string    | End timestamp in EEN format: YYYYMMDDHHMMSS.NNN | true
 is_timestamp_enabled   | boolean   | Indicates whether a timestamp should be embedded into the video (1) or not (0)
 timezone               | string    | Timezone which should be embedded into the video
-download_type          | string    | Download type to create. Defaults to `'Video'` <br><br>enum: Video, Bundle, TimeLapse
+download_type          | string    | Download type to create. Defaults to `'video'` <br><br>enum: video, bundle, timelapse
 video_format           | string    | Video format to use. Defaults to `'mp4'` (currently only MP4 is available)
 video_description      | string    | Video description
 playback_speed         | int       | Video playback speed


### PR DESCRIPTION
Competing docu updates in line with https://github.com/EENCloud/api-docs/pull/37 to follow suite with the changes implemented in [API-289] in pull https://github.com/EENCloud/videobank/pull/1021