### PR TITLE
Docs/monuszko/een 9048 document new permissions in api ref doc

### DIFF
--- a/source/includes/_api_authentication.md
+++ b/source/includes/_api_authentication.md
@@ -219,6 +219,7 @@ When the user's account has been locked the user is notified of this fact by ema
     "is_master": 1,
     "is_user_admin": 1,
     "is_layout_admin": 1,
+    "is_edit_map": 0,
     "is_live_video": 1,
     "is_export_video": 1,
     "is_recorded_video": 1,

--- a/source/includes/_api_user.md
+++ b/source/includes/_api_user.md
@@ -30,6 +30,7 @@ The <a class="definition" onclick="openModal('DOT-User')">User</a> service allow
     "is_user_admin": 1,
     "is_layout_admin": 1,
     "is_user_create_layout": 1,
+    "is_edit_map": 1,
     "is_live_video": 1,
     "is_export_video": 1,
     "is_recorded_video": 1,
@@ -150,6 +151,7 @@ is_master                            | int                  | Indicates whether 
 is_user_admin                        | int                  | This is for backwards compatibility <small>**(DEPRECATED)**</small>                  | **&check;** |
 is_layout_admin                      | int                  | Indicates whether the user is a layout administrator (1) or not (0)                  | **&check;** |
 is_user_create_layout                | int                  | Indicates whether the user can create layouts (1) or not (0)                         | **&check;** |
+is_edit_map                          | int                  | Indicates whether the user can add and edit floors, lines and shapes on the map(1), or not(0). | **&check;** |
 is_live_video                        | int                  | Indicates whether the user is authorized to access live video (1) or not (0)         | **&check;** |
 is_device_admin                      | int                  | This is for backwards compatibility <small>**(DEPRECATED)**</small>                  | **&check;** |
 is_export_video                      | int                  | Indicates whether the user is authorized to export video (1) or not (0)              | **&check;** |
@@ -255,6 +257,7 @@ is_edit_all_and_add         | Enables the management of bridges and cameras (add
 is_edit_camera_less_billing | Allows editing all camera settings except retention and full video resolution (no ability to add/delete). View Previews is enabled automatically with this permission
 is_layout_admin             | Enables the management of layouts (any user can create/edit/delete their own layouts. User layouts are always visible to admin users)
 is_user_create_layout       | Enables creation of layouts.
+is_edit_map                 | Ability to add and edit floors, lines and shapes on the map.
 is_live_video               | Allows viewing full resolution video live from cameras. View previews is enabled automatically with this permission
 is_ptz_live                 | Enables the control over pan, tilt, zoom and recall stations while viewing preview or live video of PTZ cameras. View previews is enabled automatically with this permission
 is_recorded_video           | View history browser and archived video from cameras. View previews is enabled automatically with this permission
@@ -425,6 +428,7 @@ Parameter             | Data Type | Description | Is Required
 **email**             | string    | The email address of the user | true
 sms_phone             | string    | Phone number to be used for SMS notifications | false
 is_user_create_layout | int       | Indicates whether the user can create layouts (1) or not (0) | false
+is_edit_map           | int       | Indicates whether the user can add and edit floors, lines and shapes on the map(1), or not(0). | false
 
 <aside class="notice">When TFA authentication is used and authorization code delivery via SMS is set, the user's `'sms_phone'` number must be defined</aside>
 
@@ -487,6 +491,7 @@ is_superuser                | int           | Indicates whether the user is a su
 is_account_superuser        | int           | Indicates whether the user is an account superuser (1) or not (0). Only superusers and account superusers can set this
 is_layout_admin             | int           | Indicates whether the user is a layout administrator (1) or not (0)
 is_user_create_layout       | int           | Indicates whether the user can create layouts (1) or not (0)
+is_edit_map                 | int           | Indicates whether the user can add and edit floors, lines and shapes on the map(1), or not(0).
 is_device_admin             | int           | This is for backwards compatibility <small>**(DEPRECATED)**</small>
 is_user_admin               | int           | This is for backwards compatibility <small>**(DEPRECATED)**</small>
 is_live_video               | int           | Indicates whether the user is authorized to access live video (1) or not (0)

--- a/source/includes/_api_user.md
+++ b/source/includes/_api_user.md
@@ -29,6 +29,7 @@ The <a class="definition" onclick="openModal('DOT-User')">User</a> service allow
     "is_master": 1,
     "is_user_admin": 1,
     "is_layout_admin": 1,
+    "is_user_create_layout": 1,
     "is_live_video": 1,
     "is_export_video": 1,
     "is_recorded_video": 1,
@@ -148,6 +149,7 @@ is_pending                           | int                  | Indicates whether 
 is_master                            | int                  | Indicates whether the user is in a master account (1) or not (0)                     | **&cross;** |
 is_user_admin                        | int                  | This is for backwards compatibility <small>**(DEPRECATED)**</small>                  | **&check;** |
 is_layout_admin                      | int                  | Indicates whether the user is a layout administrator (1) or not (0)                  | **&check;** |
+is_user_create_layout                | int                  | Indicates whether the user can create layouts (1) or not (0)                         | **&check;** |
 is_live_video                        | int                  | Indicates whether the user is authorized to access live video (1) or not (0)         | **&check;** |
 is_device_admin                      | int                  | This is for backwards compatibility <small>**(DEPRECATED)**</small>                  | **&check;** |
 is_export_video                      | int                  | Indicates whether the user is authorized to export video (1) or not (0)              | **&check;** |
@@ -252,6 +254,7 @@ is_export_video             | Enables to download preview and full resolution vi
 is_edit_all_and_add         | Enables the management of bridges and cameras (add/edit/delete). Refers to devices only. View previews is enabled automatically with this permission
 is_edit_camera_less_billing | Allows editing all camera settings except retention and full video resolution (no ability to add/delete). View Previews is enabled automatically with this permission
 is_layout_admin             | Enables the management of layouts (any user can create/edit/delete their own layouts. User layouts are always visible to admin users)
+is_user_create_layout       | Enables creation of layouts.
 is_live_video               | Allows viewing full resolution video live from cameras. View previews is enabled automatically with this permission
 is_ptz_live                 | Enables the control over pan, tilt, zoom and recall stations while viewing preview or live video of PTZ cameras. View previews is enabled automatically with this permission
 is_recorded_video           | View history browser and archived video from cameras. View previews is enabled automatically with this permission
@@ -415,12 +418,13 @@ curl -X PUT https://login.eagleeyenetworks.com/g/user -d '{"first_name": "[FIRST
 
 `PUT https://login.eagleeyenetworks.com/g/user`
 
-Parameter      | Data Type | Description | Is Required
----------      | --------- | ----------- | -----------
-**first_name** | string    | The first name of the user | true
-**last_name**  | string    | The last name of the user | true
-**email**      | string    | The email address of the user | true
-sms_phone      | string    | Phone number to be used for SMS notifications
+Parameter             | Data Type | Description | Is Required
+---------             | --------- | ----------- | -----------
+**first_name**        | string    | The first name of the user | true
+**last_name**         | string    | The last name of the user | true
+**email**             | string    | The email address of the user | true
+sms_phone             | string    | Phone number to be used for SMS notifications | false
+is_user_create_layout | int       | Indicates whether the user can create layouts (1) or not (0) | false
 
 <aside class="notice">When TFA authentication is used and authorization code delivery via SMS is set, the user's `'sms_phone'` number must be defined</aside>
 
@@ -482,6 +486,7 @@ is_staff                    | int           | Indicates whether the user is a st
 is_superuser                | int           | Indicates whether the user is a superuser (1) or not (0). Only superusers can set this <small>**(INTERNAL USE ONLY)**</small>
 is_account_superuser        | int           | Indicates whether the user is an account superuser (1) or not (0). Only superusers and account superusers can set this
 is_layout_admin             | int           | Indicates whether the user is a layout administrator (1) or not (0)
+is_user_create_layout       | int           | Indicates whether the user can create layouts (1) or not (0)
 is_device_admin             | int           | This is for backwards compatibility <small>**(DEPRECATED)**</small>
 is_user_admin               | int           | This is for backwards compatibility <small>**(DEPRECATED)**</small>
 is_live_video               | int           | Indicates whether the user is authorized to access live video (1) or not (0)


### PR DESCRIPTION
Document `create_layout` and `edit_map` as described by Eric here:
https://eagleeyenetworks.atlassian.net/browse/EEN-9048?jql=text%20~%20%22edit%20map%22%20order%20by%20created%20DESC

I used the following sources to get the idea what it's about:
https://eagleeyenetworks.atlassian.net/browse/EEN-8907
(descriptions from the attached files)

create_layout:
https://eagleeyenetworks.atlassian.net/browse/EEN-8815
edit_map:
https://eagleeyenetworks.atlassian.net/browse/EEN-3737

What parts of code changed with `Create Layout Permission` pull request:
https://github.com/EENCloud/videobank/commit/fd511ca9165a128d2ea39c4303bbda045f30a770

As above, but for `edit map`:
https://github.com/EENCloud/videobank/commit/cd4e14047510533b805529a4f9ec460359a5e4f0

Plus a bit of code reading.