### PR TITLE
Update annt/prev arguments.

### DIFF
--- a/source/includes/_api_annotation.md
+++ b/source/includes/_api_annotation.md
@@ -209,7 +209,7 @@ Returns an object populated by Annotation events occurring *around* the defined 
 > Request
 
 ```shell
-curl -X GET https://login.eagleeyenetworks.com/annt/annt/next -d "c=[DEVICE_ID]" -d "st=[START_TIMESTAMP]" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -G
+curl -X GET https://login.eagleeyenetworks.com/annt/annt/next -d "id=[DEVICE_ID]" -d "start_timestamp=[START_TIMESTAMP]" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -G
 ```
 
 ### HTTP Request
@@ -279,21 +279,21 @@ Returns an object populated by Annotation events occurring *around* the defined 
 > Request
 
 ```shell
-curl -X GET https://login.eagleeyenetworks.com/annt/annt/prev -d "c=[DEVICE_ID]" -d "et=[END_TIMESTAMP]" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -G
+curl -X GET https://login.eagleeyenetworks.com/annt/annt/prev -d "id=[DEVICE_ID]" -d "end_timestamp=[END_TIMESTAMP]" -H "Authentication: [API_KEY]:" --cookie "auth_key=[AUTH_KEY]" -G
 ```
 
 ### HTTP Request
 
 `GET https://login.eagleeyenetworks.com/annt/annt/prev`
 
-Parameter | Data Type | Description                                                                                                                          | Required    |
---------- | --------- | -----------                                                                                                                          |:-----------:|
-**c**     | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> the annotation is associated with                           | **&check;** |
-**et**    | string    | Timestamp as a point in time to get annotation event(s) before in EEN format: YYYYMMDDHHMMSS.NNN                                     | **&check;** |
-st        | string    | Timestamp as optional limiter for the searched annotation event(s) in EEN format: YYYYMMDDHHMMSS.NNN (defaults to maximum retention). Matches events with identical start timestamps as the specified `'st'`                                                                                                           | **&cross;** |
-ns        | string    | Namespace(s) as optional comma-separated limiter for the searched annotation event(s). Excludes all except for the specified namespace(s) by excluding results in both categories: `'new'` and `'active'` (defaults to *include all*)                                                                                       | **&cross;** |
-uuid      | string    | Unique identifier(s) as optional comma-separated limiter for the searched annotation event(s). Includes all except for the specified UUID(s) by excluding results from the `'new'` category (defaults to *include all*)                                                                                                | **&cross;** |
-flat      | string    | Flatten the search results to merge heartbeats into the main annotation level and produce one consistent prolonged searchable event. No value is required <br><br>Example: `'flat='`                                                                                                                                   | **&cross;** |
+Parameter           | Data Type | Description                                                                                                                                                                                                                               | Required    |
+------------------- | --------- | -----------                                                                                                                                                                                                                               |:-----------:|
+**id**              | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> the annotation is associated with                                                                                                                                | **&check;** |
+**end_timestamp**   | string    | Timestamp as a point in time to get annotation event(s) before in EEN format: YYYYMMDDHHMMSS.NNN                                                                                                                                          | **&check;** |
+start_timestamp     | string    | Timestamp as optional limiter for the searched annotation event(s) in EEN format: YYYYMMDDHHMMSS.NNN (defaults to maximum retention). Matches events with identical start timestamps as the specified `'start_timestamp'`                 | **&cross;** |
+namespace           | string    | Namespace(s) as optional comma-separated limiter for the searched annotation event(s). Excludes all except for the specified namespace(s) by excluding results in both categories: `'new'` and `'active'` (defaults to *include all*)     | **&cross;** |
+uuid                | string    | Unique identifier(s) as optional comma-separated limiter for the searched annotation event(s). Includes all except for the specified UUID(s) by excluding results from the `'new'` category (defaults to *include all*)                   | **&cross;** |
+flat                | string    | Flatten the search results to merge heartbeats into the main annotation level and produce one consistent prolonged searchable event. No value is required <br><br>Example: `'flat='`                                                      | **&cross;** |
 
 > Json Response
 


### PR DESCRIPTION
This is part of EEN-9820.

Update API-tests with new argument names (full names).

API-test result to proof that these arguments are already supported:
[ANNT_PREV_after.txt](https://github.com/EENCloud/api-docs/files/2529258/ANNT_PREV_after.txt)
