### PR TITLE
HTTP status code clean up

### DIFF
--- a/source/includes/_api_aaa.md
+++ b/source/includes/_api_aaa.md
@@ -34,14 +34,14 @@ last_name            | string    | User last name
 timezone             | string    | Timezone name (defaults to `'US/Pacific'`)
 is_api_access_needed | boolean   | Grant API access to this new account
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Account has been created and a confirmation email has been sent to the provided email address
 400	| Unexpected or non-identifiable arguments are supplied
 406	| Realm is invalid due to not being a root realm
 409	| Email address has already been registered for the specified realm
-202	| Account has been created and a confirmation email has been sent to the provided email address
 
 <!--===================================================================-->
 ## Validate Account
@@ -78,17 +78,17 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 user_id   | string    | Unique identifier for validated user
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 406	| Information supplied could not be verified
 409	| Account has already been activated
 412	| User is disabled
 460	| Account is inactive
-200	| User has been authorized for access to the realm
 
 <!--===================================================================-->
 ## 1. Forgot Password
@@ -114,10 +114,11 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **email** | string    | Email address | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | A reset email has been sent to the supplied email address. This status will be provided even if the email address was not found. This prevents attacks to discover user accounts
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 406	| Information supplied could not be verified
@@ -125,7 +126,6 @@ HTTP Status Code | Description
 460	| Account is inactive
 461	| Account is pending
 462	| User is pending
-202	| A reset email has been sent to the supplied email address. This status will be provided even if the email address was not found. This prevents attacks to discover user accounts
 
 <!--===================================================================-->
 ## 2. Check Password Reset Token
@@ -147,17 +147,17 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **token** | string    | Password reset token provided in email | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Token is valid
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 406	| Token not valid or not found
 412	| User is disabled
 460	| Account is inactive
 461	| Account is pending
-202	| Token is valid
 
 <!--===================================================================-->
 ## 3. Reset Password
@@ -195,17 +195,17 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 user_id   | string    | Unique identifier for validated user
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 406	| Token not valid or not found
 412	| User is disabled
 460	| Account is inactive
 461	| Account is pending
-200	| User has been authorized for access to the realm
 
 <!--===================================================================-->
 ## Resend Registration Email
@@ -228,17 +228,17 @@ Parameter | Data Type | Description | Is Required
 **email** | string    | Email address of the account contact for a pending account | true
 realm     | string    | Realm (defaults to current user's realm)
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Account was located and verified to be in the pending state. A registration email has been recreated and sent to the provided email address
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| Account with this email address and realm could not be found
 409	| Account is already active (not pending)
 412	| User is disabled
 460	| Account is inactive
-202	| Account was located and verified to be in the pending state. A registration email has been recreated and sent to the provided email address
 
 <!--===================================================================-->
 ## Resend User Verification Email
@@ -261,10 +261,11 @@ Parameter | Data Type | Description | Is Required
 **email** | string    | Email address of the new user | true
 realm     | string    | Realm (defaults to current user's realm)
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | User was located and verified to be in the pending state. A verification email has been recreated and sent to the provided email address
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| User with this email address and realm could not be found
@@ -272,7 +273,6 @@ HTTP Status Code | Description
 412	| User is disabled
 460	| Account is inactive
 461	| Account is pending
-202	| User was located and verified to be in the pending state. A verification email has been recreated and sent to the provided email address
 
 <!--===================================================================-->
 ## Change Password
@@ -313,15 +313,15 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a> of the user having their password changed
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User password was changed successfully
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 404	| User with the `'id'` provided cannot be found
 406	| The `'current_password'` provided does not match the password of the authenticated user
-200	| User password was changed successfully
 
 <!--===================================================================-->
 ## Switch Account
@@ -343,14 +343,14 @@ Parameter  | Data Type | Description
 ---------  | --------- | -----------
 account_id | string    | <a class="definition" onclick="openModal('DOT-Account-ID')">Account ID</a> of the account to login to. Defaults to the account which the user belongs to
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Account context switch successful
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 404	| Account with the `'account_id'` provided cannot be found
-200	| Account context switch successful
 
 <!--===================================================================-->
 ## Single Sign On
@@ -380,14 +380,14 @@ curl -X POST https://login.eagleeyenetworks.com/g/sso -H "Authentication: [API_K
 
 `POST https://login.eagleeyenetworks.com/g/sso`
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Account context switch successful
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 404	| Account with the `'account_id'` provided cannot be found
-200	| Account context switch successful
 
 
 <!--===================================================================-->
@@ -406,12 +406,12 @@ curl -X GET https://login.eagleeyenetworks.com/g/aaa/isauth -H "Authentication: 
 
 `GET https://login.eagleeyenetworks.com/g/aaa/isauth`
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
-401 | Unauthorized due to invalid session cookie
 200 | User authentication is valid
+401 | Unauthorized due to invalid session cookie
 
 
 <!--===================================================================-->
@@ -430,10 +430,10 @@ curl -X POST https://login.eagleeyenetworks.com/g/aaa/logout -H "Authentication:
 
 `POST https://login.eagleeyenetworks.com/g/aaa/logout`
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+204 | User has been logged out
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
-204	| User has been logged out

--- a/source/includes/_api_account.md
+++ b/source/includes/_api_account.md
@@ -253,15 +253,15 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Account-ID')">Account ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Account not found with the supplied ID
-200	| Request succeeded
 
 <!--===================================================================-->
 ## Create Account
@@ -319,15 +319,16 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Account-ID')">Account ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 409	| Another account with the supplied contact email address already exists
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Account
@@ -419,15 +420,15 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Account-ID')">Account ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Account not found with the supplied ID
-200	| Request succeeded
 
 <!--===================================================================-->
 ## Delete Account
@@ -449,15 +450,15 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Account-ID')">Account ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Delete succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Account not found with the supplied ID
-200	| Delete succeeded
 
 <!--===================================================================-->
 ## Get List of Accounts
@@ -532,14 +533,14 @@ Array Index | Attribute              | Data Type | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
 
 <!--===================================================================-->
 ## Account Statistics
@@ -593,15 +594,15 @@ Parameter     | Data Type  | Description
 account_total | int        | Total number of sub-accounts (defaults to 0 for sub-accounts)
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
 
 ### Total Number of Users
 <!--===================================================================-->
@@ -637,15 +638,15 @@ Parameter  | Data Type  | Description
 user_total | int        | Total number of users
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
 
 ### Total Number of Bridges
 <!--===================================================================-->
@@ -708,15 +709,15 @@ Parameter    | Data Type  | Description
 camera_total | int        | Total number of cameras
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
 
 ### HTTP Response (Json Attributes)
 
@@ -725,15 +726,15 @@ Parameter    | Data Type  | Description
 bridge_total | int        | Total number of bridges
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
 
 ### Total Number of Online Users
 <!--===================================================================-->
@@ -769,15 +770,15 @@ Parameter         | Data Type  | Description
 online_user_total | int        | Total number of online users
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
 
 ### Total Number of Online Cameras
 <!--===================================================================-->
@@ -813,12 +814,13 @@ Parameter           | Data Type  | Description
 camera_online_total | int        | Total number of online cameras
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Account not found
-200 | Request succeeded
+

--- a/source/includes/_api_action.md
+++ b/source/includes/_api_action.md
@@ -24,14 +24,15 @@ curl -X POST https://login.eagleeyenetworks.com/g/action/allon -H "Authenticatio
 
 `POST https://login.eagleeyenetworks.com/g/action/allon`
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-202	| Request succeeded
+
 
 <!--===================================================================-->
 ## Turn All Cameras Off
@@ -49,14 +50,15 @@ curl -X POST https://login.eagleeyenetworks.com/g/action/alloff -H "Authenticati
 
 `POST https://login.eagleeyenetworks.com/g/action/alloff`
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-202	| Request succeeded
+
 
 <!--===================================================================-->
 ## Recording On
@@ -80,14 +82,15 @@ device_id     | string    | ID of the camera to record. If this parameter and th
 layout_id     | string    | ID of the layout for which cameras will be set to record. All cameras in the layout will be affected. If this parameter and the `'device_id'` parameter are omitted, all cameras with write access available to the requesting user will be used
 recording_key | string    | A key used to tag this recording. Can be used to retrieve this recording info later using the GET `'recording'` service
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-202	| Request succeeded
+
 
 <!--===================================================================-->
 ## Recording Off
@@ -110,11 +113,12 @@ Parameter | Data Type | Description
 device_id | string    | ID of the camera to turn off recording for. If this parameter and the `'layout_id'` parameter are omitted, all cameras with write access available to the requesting user will be used
 layout_id | string    | ID of the layout for which cameras will have recording turned off. All cameras in the layout will be affected. If this parameter and the `'device_id'` parameter are omitted, all cameras with write access available to the requesting user will be used
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-202	| Request succeeded
+

--- a/source/includes/_api_annotation.md
+++ b/source/includes/_api_annotation.md
@@ -81,14 +81,15 @@ Parameter     | Data Type     | Description                                     
 **id**        | string        | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> the annotation is associated with                   | **&check;** |
 **uuid**      | array[string] | Array of comma-separated annotation UUIDs to return                                                                          | **&check;** |
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Create Annotation
@@ -135,14 +136,15 @@ cameraid  | string    | <a class="definition" onclick="openModal('DOT-Camera-ID'
 ts        | string    | Timestamp associated with the annotation
 ns        | string    | Namespace associated with the annotation
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Annotation
@@ -191,14 +193,15 @@ cameraid  | string    | <a class="definition" onclick="openModal('DOT-Camera-ID'
 ts        | string    | Timestamp associated with the annotation
 ns        | string    | Namespace associated with the annotation
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Next Annotation
@@ -261,14 +264,15 @@ active    | array[string]     | Array of all annotation UUIDs active around the 
 
 <aside class="notice">If the search criteria has not been matched by any events, the return will be <i>null</i></aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Previous Annotation
@@ -331,14 +335,15 @@ active    | array[string]     | Array of all annotation UUIDs active around the 
 
 <aside class="notice">If the search criteria has not been matched by any events, the return will be <i>null</i></aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Window of Annotations
@@ -403,14 +408,15 @@ ts        | string            | Closest matching timestamp to the requested (to 
 new       | array[array[obj]] | Array of arrays with each returned element being an annotation object with Json-formatted data <br>(See [Annotation Model](#annotation-model) for the returned annotation array structure)
 active    | array[string]     | Array of all annotation UUIDs returned based on the specified criteria
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Annotations
@@ -487,14 +493,15 @@ Array Index | Attribute | Data Type | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Events
@@ -574,11 +581,12 @@ Array Index | Attribute | Data Type | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_asset.md
+++ b/source/includes/_api_asset.md
@@ -136,16 +136,17 @@ JPEG<file_content>
 
 The returned response is binary image data in JPEG format
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 301	| Asset has been moved to a different archiver
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Image not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get Video
@@ -183,10 +184,11 @@ FLV<file_content>
 
 The returned response is binary video data in FLV format
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 301	| Asset has been moved to a different archiver
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
@@ -194,8 +196,10 @@ HTTP Status Code | Description
 404	| Camera not provisioned
 404	| Camera get error
 410	| Video is out of retention
-503	| Camera tag maps not loaded
-200	| Request succeeded
+502 | Bad Gateway.  We were unable to return the requested data.  Please try again.
+503 | Internal Camera Tag Maps Error.  Please contact our support department.
+504 | Gateway Timeout.  We were unable to return the requested data inside our time limit.  Please try again.
+
 
 <!--===================================================================-->
 ## Prefetch Image
@@ -353,15 +357,16 @@ Parameter | Data Type | Description
 t         | string    | Type of the requested event denoted by the object's [Four CC](#event-objects)
 s         | string    | Timestamp of the image in EEN format: YYYYMMDDHHMMSS.NNN
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 301	| Asset has been moved to a different archiver
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Videos
@@ -432,12 +437,13 @@ s         | string    | Start timestamp of the image in EEN format: YYYYMMDDHHMM
 e         | string    | End timestamp of the image in EEN format: YYYYMMDDHHMMSS.NNN
 id        | int       | Unique identifier of the video
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 301	| Asset has been moved to a different archiver
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_authentication.md
+++ b/source/includes/_api_authentication.md
@@ -102,10 +102,11 @@ For TFA, the system uses the parameter `'sms_phone'` from the [User Model](#user
 
 The TFA-related user's data (i.e. SMS phone or email), once set at the time of user's account creation, can only be modified by that user alone. Any such modification will also be TFA authenticated. Account superuser cannot change this data for security reasons
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authenticated (Body contains Json-formatted result)
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Invalid credentials supplied
 402	| Account is suspended
@@ -113,7 +114,7 @@ HTTP Status Code | Description
 461	| Account is pending
 412\*	| User is disabled
 462	| User is pending (This will be thrown before 401 if the username is valid and account is active)
-200	| User has been authenticated (Body contains Json-formatted result)
+
 
 \*Code 412 is also returned if TFA is used and the user's account has been locked due to more than 3 failed attempts to authorize with a TFA code
 
@@ -154,10 +155,11 @@ TFA code expiration is *15 minutes*
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded (TFA code has been sent to the user)
 400	| Unexpected or non-identifiable arguments are supplied
 412	| Unable to send TFA code with the TFA type selected
 415	| Specified TFA type not supported
-200	| Request succeeded (TFA code has been sent to the user)
+
 
 <!--===================================================================-->
 ## 3. Authorize
@@ -317,25 +319,27 @@ When the user's account has been locked the user is notified of this fact by ema
 
 When successful, this API call returns Json data structure following the [User Model](#user-model) with the additional `'user_id'` field, which is present during Authorize and is identical to `'id'`
 
-### Error Status Codes
+### HTTP Status Codes
 
 **When using Simple Authentication**
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Invalid token supplied
-200	| User has been authorized for access to the realm
+
 
 **When using TFA**
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Invalid token supplied, missing TFA code or attempting to authorize with expired TFA code
 406	| Invalid TFA supplied or invalid TFA and invalid token supplied
 429	| This user's account has been locked due to more than 3 failed attempts to Authorize
-200	| User has been authorized for access to the realm
+
 
 <!--===================================================================-->
 ## Forced vs. Optional TFA
@@ -385,10 +389,11 @@ This API call returns no data
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded (Proceed to verification)
 400	| Unexpected or non-identifiable arguments are supplied (i.e. update of `'sms_phone'` is requested with `'two_factor_authentication_type'` set to `'email'` or vice versa)
 401	| Invalid credentials supplied
 415	| Invalid TFA code delivery method supplied in `'two_factor_authentication_type'`
-200	| Request succeeded (Proceed to verification)
+
 
 ### 2. Verify update request with TFA
 
@@ -406,9 +411,10 @@ This API call returns no data
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 406	| Invalid TFA code supplied
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Authorized Devices

--- a/source/includes/_api_bridge.md
+++ b/source/includes/_api_bridge.md
@@ -601,15 +601,16 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Bridge-ID')">Bridge ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| No device matching the Connect ID or GUID has been found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Add Bridge to <a class="definition" onclick="openModal('DOT-EEVB')">EEVB</a>
@@ -646,10 +647,11 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Bridge-ID')">Bridge ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
@@ -657,7 +659,7 @@ HTTP Status Code | Description
 409	| Connect ID or GUID is currently already in use by an account
 410	| Communication cannot be made to attach the camera to the bridge
 415	| Device associated with the given GUID is unsupported
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Bridge
@@ -699,16 +701,17 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Bridge-ID')">Bridge ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Device matching the ID was not found
 463	| Unable to communicate with the camera to add/delete camera settings, contact support
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Delete Bridge
@@ -730,16 +733,17 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Bridge-ID')">Bridge ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Device matching the ID was not found
 463	| Unable to communicate with the camera or bridge, contact support
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Bridges
@@ -891,11 +895,12 @@ Array Index | Attribute           | Data Type            | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_camera.md
+++ b/source/includes/_api_camera.md
@@ -1456,14 +1456,56 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
+
+<!--===================================================================-->
+## Get Camera's RTSP URLs
+<!--===================================================================-->
+
+Returns the full RTSP URLs for a Camera object by ID.
+
+> Request
+
+```shell
+curl -X GET https://login.eagleeyenetworks.com/g/device/rtsp -d "id=[CAMERA_ID]" -H "Authentication: [API_KEY]" --cookie "auth_key=[AUTH_KEY]" -G
+```
+
+### HTTP Request
+
+`GET https://login.eagleeyenetworks.com/g/device/rtsp`
+
+Parameter | Data Type | Description | Is Required
+--------- | --------- | ----------- | -----------
+**id**    | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> | true
+
+
+> Json Response
+
+```json
+{
+  "preview_url": "rtsp://...",
+  "video_url": "rtsp://..."
+}
+```
+
+
+### HTTP Status Codes
+
+HTTP Status Code | Description
+---------------- | -----------
+200 | Request succeeded
+400 | Unexpected or non-identifiable arguments are supplied
+401 | Unauthorized due to invalid session cookie
+403 | Forbidden due to the user missing the necessary privileges
+
 
 <!--===================================================================-->
 ## Add Camera to <a class="definition" onclick="openModal('DOT-Bridge')">Bridge</a>
@@ -1484,9 +1526,25 @@ curl -X PUT https://login.eagleeyenetworks.com/g/device -d '{"name":"[NAME]","ti
 Parameter | Data Type     | Description | Is Required
 --------- | ---------     | ----------- | -----------
 **name**  | string        | Camera name | true
-**[settings](#camera-settings)** | json          | Json object of basic settings (location, motion regions, etc.) | true
+**[settings](#camera-settings)** | json          | Json object of basic settings (bridge, GUID, username, password, location, motion regions, etc.)  Please note that the GUID value is case-sensitive and should exactly match what is returned by the camera.| true
 timezone  | string        | If unspecified, this will default to the camera’s bridge timezone
 tags      | array[string] | Array of strings each representing a tag name
+
+
+> Example JSON settings object
+
+```json
+{
+  "name": "",
+  "settings": {
+    "bridge": "",
+    "guid": "",
+    "username": "",
+    "password": ""
+  }
+}
+```
+
 
 > Json Response
 
@@ -1502,10 +1560,11 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
@@ -1513,7 +1572,7 @@ HTTP Status Code | Description
 409	| Connect ID or GUID is currently already in use by an account
 410	| Communication cannot be made to attach the camera to the bridge
 415	| Device associated with the given GUID is unsupported
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Camera
@@ -1555,16 +1614,17 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Device matching the ID was not found
 463	| Unable to communicate with the camera to add/delete camera settings, contact support
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Delete Camera
@@ -1586,16 +1646,17 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Camera-ID')">Camera ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Device matching the ID was not found
 463	| Unable to communicate with the camera or bridge, contact support
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Cameras
@@ -1747,11 +1808,12 @@ Array Index | Attribute           | Data Type     | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_feedback.md
+++ b/source/includes/_api_feedback.md
@@ -27,11 +27,12 @@ Parameter   | Data Type | Description | Is Required
 **subject** | string    | Subject of the feedback | true
 **message** | string    | Feedback message content | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+202 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-202	| Request succeeded
+

--- a/source/includes/_api_layout.md
+++ b/source/includes/_api_layout.md
@@ -155,15 +155,16 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Layout-ID')">Layout ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Layout ID not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Create Layout
@@ -202,14 +203,15 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Layout-ID')">Layout ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Layout
@@ -249,15 +251,16 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-Layout-ID')">Layout ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Layout ID not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Delete Layout
@@ -279,15 +282,16 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-Layout-ID')">Layout ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Layout matching the ID was not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Layouts
@@ -342,11 +346,12 @@ Array Index | Attribute   | Data Type     | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_managed_switch.md
+++ b/source/includes/_api_managed_switch.md
@@ -114,15 +114,16 @@ Parameter | Data Type | Description                                             
 **switch_guid**  | string    | <a class="definition" onclick="openModal('DOT-GUID')">GUID</a> of the managed switch                                          | **&check;** |
 bridge_id        | string    | <a class="definition" onclick="openModal('DOT-Bridge-ID')">Bridge ID</a> of the connected or integrated bridge                | **&cross;** |
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Bridge or managed switch not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Managed Switch
@@ -145,15 +146,16 @@ Parameter        | Data Type | Description                                      
 **switch_guid**  | string    | <a class="definition" onclick="openModal('DOT-GUID')">GUID</a> of the managed switch                                                 | **&check;** |
 name             | string    | Name of the managed switch                                                                                                           | **&cross;** |
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Bridge or managed switch not found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Control Managed Switch
@@ -193,17 +195,18 @@ Parameter | Data Type | Description
 status    | string    | Command status (e.g. `'Success'`)
 details   | string    | Command resolution
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Bridge or managed switch not found
 406	| Managed switch is not currently in a valid state to be controlled
 415	| Invalid command supplied
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Control Camera Power
@@ -244,17 +247,18 @@ Parameter | Data Type | Description
 status    | string    | Command status (e.g. `'Success'`)
 details   | string    | Command resolution
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| Bridge or managed switch not found
 406	| Managed switch is not currently in a valid state to be controlled
 415	| Invalid command supplied
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Managed Switches
@@ -377,11 +381,12 @@ comment           | string        | Comment stored on switch                    
 [port_details](#managed-switch-port_details) | array[obj]    | List of *port details* objects                                                                | **&cross;** |
 available_bridges | array[string] | List of available bridge <a class="definition" onclick="openModal('DOT-ESN')">ESNs</a>, i.e. bridges that this switch can be attached to                                                                                                                                                           | **&cross;** |
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_metric.md
+++ b/source/includes/_api_metric.md
@@ -137,15 +137,16 @@ Index     | Data Type | Description
 0         | string    | EEN Timestamp: YYYYMMDDHHMMSS.NNN
 1         | float     | Bytes difference
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Metrics not found
-200 | Request succeeded
+
 
 <!--===================================================================-->
 ## Camera Bandwidth
@@ -263,12 +264,13 @@ Index     | Data Type | Description
 0         | string    | EEN Timestamp: YYYYMMDDHHMMSS.NNN
 1         | int       | Motion activity value
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
 404 | Metrics not found
-200 | Request succeeded
+

--- a/source/includes/_api_notice.md
+++ b/source/includes/_api_notice.md
@@ -68,17 +68,18 @@ Array Index | Attribute    | Data Type | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
-406	| Information supplied could not be verified
 402	| Account is suspended
+406 | Information supplied could not be verified
+412 | User is disabled
 460	| Account is inactive
 409	| Account has already been activated
-412	| User is disabled
-200	| User has been authorized for access to the realm
+
 
 <!--===================================================================-->
 ## Accept Terms of Service for User
@@ -116,18 +117,19 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| Notice title was not found
 406	| Information supplied could not be verified
-460	| Account is inactive
 409	| Account has already been activated
 412	| User is disabled
-200	| User has been authorized for access to the realm
+460 | Account is inactive
+
 
 <!--===================================================================-->
 ## Get Terms of Service for Account
@@ -219,17 +221,18 @@ Array Index | Attribute         | Data Type | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
-406	| Information supplied could not be verified
 402	| Account is suspended
-460	| Account is inactive
+406 | Information supplied could not be verified
 409	| Account has already been activated
 412	| User is disabled
-200	| User has been authorized for access to the realm
+460 | Account is inactive
+
 
 <!--===================================================================-->
 ## Create Terms of Service for Account
@@ -293,18 +296,18 @@ timestamp         | string    | Date of the term of service
 url               | string    | URL of the file containing the text for the notice
 status            | string    | Status of the term of service (`'active'`, `'retired'`)
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| Terms Title was not found
 406	| Information supplied could not be verified
-460	| Account is inactive
 409	| Account has already been activated
 412	| User is disabled
-200	| User has been authorized for access to the realm
+460 | Account is inactive
 
 <!--===================================================================-->
 ## Update Terms of Service for Account
@@ -368,18 +371,19 @@ status            | string    | Status of the term of service (`'active'`, `'ret
 
 <!--TODO: Investigate whether the curl request and response are correct (why "version" is an unexpected argument)-->
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| Notice title was not found
 406	| Information supplied could not be verified
-460	| Account is inactive
 409	| Account has already been activated
 412	| User is disabled
-200	| User has been authorized for access to the realm
+460 | Account is inactive
+
 
 <!--===================================================================-->
 ## Delete Terms of Service for Account
@@ -437,15 +441,15 @@ timestamp          | string    | Date of the term of service
 url                | string    | URL of the file containing the text for the term of service
 status             | string    | This field is no longer being used <small>**(DEPRECATED)**</small>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | User has been authorized for access to the realm
 400	| Unexpected or non-identifiable arguments are supplied
 402	| Account is suspended
 404	| Notice title was not found
 406	| Information supplied could not be verified
-460	| Account is inactive
 409	| Account has already been activated
 412	| User is disabled
-200	| User has been authorized for access to the realm
+460 | Account is inactive

--- a/source/includes/_api_pngspan.md
+++ b/source/includes/_api_pngspan.md
@@ -85,10 +85,10 @@ flflags             | string       | Limits span rendering to spans with the fla
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session
 404	| Not found if camera, etag or table cannot be found
-500	| Problem occurred during data processing or rendering
-200	| Request succeeded
+
 
 <!-- TODO: Confirm a scenario where the error code is applicable: 408	| Required arguments are missing or invalid -->

--- a/source/includes/_api_poll.md
+++ b/source/includes/_api_poll.md
@@ -434,14 +434,15 @@ If a specified event has not been triggered on the device/account, it will not b
 
 <aside class="warning">The status parameter takes precedence (if multiple) and all others will become suppressed when polling over HTTP POST /poll</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Polling
@@ -536,14 +537,15 @@ The returned values are in accordance with the [returned resource types](#resour
 
 <aside class="warning">The status parameter will be omitted (if multiple), all others will be returned when polling over HTTP GET /poll</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## WebSocket Polling
@@ -648,12 +650,13 @@ Parameter | Data Type | Description | Is Required
 
 The server reply completes the handshake. A successful server reply is followed by data transfer
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+101 | Switching protocols
 400	| Header is not understood or has an incorrect value
-101	| Switching protocols
+
 
 ### Data Exchange
 
@@ -669,11 +672,12 @@ The connection can be severed at any given time using the *close* function
 
 WebSocket polling will additionally return *message* response error codes for each individual encountered problem based on the [Errors](#errors) section
 
-### Message Error Status Codes
+### Message HTTP Status Codes
 
 Status Code | Description
 ----------- | -----------
+200 | OK
 400	| Invalid resource
 401	| Access denied
 412	| Auth lost
-200	| OK
+

--- a/source/includes/_api_recording.md
+++ b/source/includes/_api_recording.md
@@ -45,14 +45,15 @@ Parameter         | Data Type | Description | Is Required
 ---------         | --------- | ----------- | -----------
 **recording_key** | string    | Recording key | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update Recording Object
@@ -88,11 +89,12 @@ Parameter | Data Type | Description
 </details>
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_api_search.md
+++ b/source/includes/_api_search.md
@@ -71,14 +71,15 @@ camera_ids  | array[string] | Array of camera IDs which had recording started fo
 layout_name | string        | Name of layout at the time the recording started
 user_id     | string        | ID of the user who started/stopped the recording
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
-200 | Request succeeded
+
 
 <!--===================================================================-->
 ## Search Annotations
@@ -115,11 +116,12 @@ Parameter | Data Type     | Description
 </details>
 
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400 | Unexpected or non-identifiable arguments are supplied
 401 | Unauthorized due to invalid session cookie
 403 | Forbidden due to the user missing the necessary privileges
-200 | Request succeeded
+

--- a/source/includes/_api_user.md
+++ b/source/includes/_api_user.md
@@ -395,15 +395,16 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a> | false
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| No user matching the unique identifier was found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Create User
@@ -446,15 +447,16 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 409	| The email address is currently already in use
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Update User
@@ -539,15 +541,16 @@ Parameter | Data Type | Description
 --------- | --------- | -----------
 id        | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| No user matching the unique identifier was found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Delete User
@@ -569,15 +572,16 @@ Parameter | Data Type | Description | Is Required
 --------- | --------- | ----------- | -----------
 **id**    | string    | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a> | true
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 400	| Unexpected or non-identifiable arguments are supplied
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
 404	| No user matching the unique identifier was found
-200	| Request succeeded
+
 
 <!--===================================================================-->
 ## Get List of Users
@@ -652,10 +656,11 @@ Array Index | Attribute   | Data Type     | Description
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 
-### Error Status Codes
+### HTTP Status Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | Request succeeded
 401	| Unauthorized due to invalid session cookie
 403	| Forbidden due to the user missing the necessary privileges
-200	| Request succeeded
+

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,7 +1,10 @@
-# Errors
+# HTTP Response Codes
 
 HTTP Status Code | Description
 ---------------- | -----------
+200 | The request was fulfilled successfully
+202 | The request has been accepted for processing, but the processing has not been completed
+204 | User has been logged out
 400	| The request had bad syntax or was inherently impossible to be satisfied
 401	| Supplied credentials are not valid / invalid session cookie
 402	| Account is suspended
@@ -17,6 +20,3 @@ HTTP Status Code | Description
 461	| Account is pending
 462	| User is pending
 463	| Unable to communicate with the camera or bridge, contact support
-200	| The request was fulfilled successfully
-202	| The request has been accepted for processing, but the processing has not been completed
-204	| User has been logged out

--- a/source/includes/_http_response_codes.md
+++ b/source/includes/_http_response_codes.md
@@ -1,0 +1,48 @@
+# HTTP Response Codes
+
+<!--===================================================================-->
+## Overview
+<!--===================================================================-->
+
+We use the established HTTP status codes.  This is the general description for all the codes we return.  Each API call defines any additional meaning intended with the return codes it uses.
+
+HTTP Status Code | Description
+---------------- | -----------
+200 | The request was fulfilled successfully
+201 | The request has been created and a webhook will be triggered upon completion or error
+202 | The request has been accepted for processing, but the processing has not been completed
+204 | User has been logged out
+
+
+HTTP Status Code | Description
+---------------- | -----------
+301 | Item has been moved, please follow redirect
+
+
+HTTP Status Code | Description
+---------------- | -----------
+400	| The request had bad syntax or was inherently impossible to be satisfied
+401	| Supplied credentials are not valid / invalid session cookie
+402	| Account is suspended
+403	| Forbidden due to the user missing the necessary privileges
+404	| Element not found (section specific)
+405	| Unexpected method used for the HTTP request
+406	| Realm is invalid due to not being a root realm
+409	| Email address has already been registered for the specified realm
+410	| Communication cannot be made to attach the camera to the bridge
+412	| User is disabled
+415	| Device associated with the given GUID is unsupported
+429 | Too many requests.  Client has exceeded the maximum requests per second, please slow down.
+460	| Account is inactive
+461	| Account is pending
+462	| User is pending
+463	| Unable to communicate with the camera or bridge, contact support
+
+
+HTTP Status Code | Description
+---------------- | -----------
+500 | Internal Error.  Please contact our support department.
+502 | Bad Gateway.  We were unable to return the requested data.  Please try again.
+503 | Internal Camera Tag Maps Error.  Please contact our support department.
+504 | Gateway Timeout.  We were unable to return the requested data inside our time limit.  Please try again.
+

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -26,20 +26,6 @@ Since the API is based on REST principles, it’s very easy to write and test ap
 
 ### Create a Developer Account
 
-> Request
-
-```shell
-curl -X PUT https://login.eagleeyenetworks.com/g/user -d '{"first_name": "[FIRST_NAME]", "last_name": "[LAST_NAME]", "email": "[EMAIL]"}' -H "Authentication: [API_KEY]" -H "content-type: application/json" --cookie "auth_key=[AUTH_KEY]" -v
-```
-
-> Json Response
-
-```json
-{
-    "id": "ca0ffa8c"
-}
-```
-
 <aside><form action="https://login.eagleeyenetworks.com/api_signup.html"><button>&#9654; Create Developer Account</button></form></aside>
 
 To get started with the Eagle Eye Video API you will need an *API Key*. This is used to identify you and your application. It also makes everything secure. To get an *API Key* you will need an account (so that you have some place to do some testing). You can either use your existing account or create a *Developer Account*. You can create an *API Key* in your existing account under the *Account Settings*

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,6 +9,7 @@ toc_footers:
 
 includes:
   - introduction
+  - http_response_codes
 #  - api_types
   - api_authentication
   - api_aaa
@@ -28,7 +29,7 @@ includes:
   - api_feedback
 #  - api_recording
 #  - api_search
-  - errors
+#  - errors
   - faq
   - sample_code
   - definition_of_terms


### PR DESCRIPTION
- changed `errors` to `HTTP status codes`
- moved `HTTP status codes` to the second item
- removed example call to create a developer account
- added /g/device/rtsp call