### PR TITLE
[NOTRACKER] updates to layout documentation

### DIFF
--- a/source/includes/_api_layout.md
+++ b/source/includes/_api_layout.md
@@ -120,10 +120,10 @@ Parameter | Data Type | Description | Is Required
 Parameter | Data Type     | Description
 --------- | ---------     | -----------
 name      | string        | Layout pane name
-type      | string        | Layout types: <br>`'preview'` - shows live preview images form cameras <br>`'carousel'` - rotates between preview images, IDs of cameras need to be included in the cameras array along with an integer in the delay array. The delay is an integer value of milliseconds as too how long the Camera will be displayed before switching to the next Camera. A `'carousel'` with only one camera is the same as preview <br>`'click'` - respond to click for other cameras in layout <br>`'motion'` - respond to motion for other cameras in layout <br>`'map'` - a static map with camera icons located on it <br>`'url'` - displays the contents of the url in the pane as a frame
+type      | string        | Layout types: <br>`'preview'` - shows live preview images form cameras <br>`'click'` - respond to click for other cameras in layout <br>`'motion'` - respond to motion for other cameras in layout <br>`'map'` - a static map with camera icons located on it <br>`'url'` - displays the contents of the url in the pane as a frame
 pane_id   | int           | ID given to pane when created by the Layout Manager
 size      | int           | Size of displayed image: <br>`1` - small <br>`2` - medium <br>`3` - large
-cameras   | array[string] | Array of camera IDs (For `'carousel'` cycle through the camera IDs with the delay setting in the corresponding `'delay'` property)
+cameras   | array[string] | Array of camera IDs contained in a pane
 
 ### Layout - configuration - settings
 

--- a/source/includes/_api_layout.md
+++ b/source/includes/_api_layout.md
@@ -31,7 +31,7 @@ Rendered Layouts on Web and Mobile:
     "id": "0b58ec7a-61e4-11e3-8f7d-523445989f37",
     "name": "Everything",
     "types": [
-        "mobile"
+        "desktop"
     ],
     "permissions": "SWRD",
     "current_recording_key": null,
@@ -101,7 +101,7 @@ Property              | Data Type            | Description                      
 --------              | ---------            | -----------                                                                                          |:-----------:| --------
 **id**                | string               | <a class="definition" onclick="openModal('DOT-Layout-ID')">Layout ID</a> automatically generated and assigned during creation                                                                                                                                            | **&cross;** | **<sub><form action="#get-layout"><button>GET</button></form></sub>** <br>**<sub><form action="#update-layout"><button>POST</button></form></sub>** <br>**<sub><form action="#delete-layout"><button>DELETE</button></form></sub>**
 **name**              | string               | Name of the layout                                                                                   | **&check;** | **<sub><form action="#create-layout"><button>PUT</button></form></sub>**
-**types**             | array[string]        | Specifies target(s) for layout. Multiple values are allowed                                          | **&check;** | **<sub><form action="#create-layout"><button>PUT</button></form></sub>**
+**types**             | array[string]        | Specifies target(s) for layout.                                                                      | **&check;** | **<sub><form action="#create-layout"><button>PUT</button></form></sub>**
 **[configuration](#layout-configuration)** | json             | Json object of layout configuration                                                 | **&check;** | **<sub><form action="#create-layout"><button>PUT</button></form></sub>**
 json                  | string               | Json encoded string. The same content as the `'configuration'` field <small>**(DEPRECATED)**</small> | **&cross;** |
 permissions           | string               | String of zero or more characters. Each character defines a permission that the current user has for the layout  <br><br>Permissions include: <br>`'R'` - user can view this layout <br>`'W'` - user can modify this layout <br>`'D'` - user can delete this layout <br>`'S'` - user can share this layout                                                                                                                                              | **&cross;** |


### PR DESCRIPTION
Removed unused / unsupported feature for layout panes.

From updating the layout model to postgres I've run across old code indicating a carousel feature that is not in use.  Decision was made over a year ago to default layout.types to ["desktop"]

Of the 15767 layouts, 2935 were != 'desktop' being a mix of 'mobile' and 'iphone' layout types.  As the API is consumed by those mobile products they have received nothing but 'desktop' type layout attributes with no error. 

![Screenshot from 2019-08-16 10-01-29](https://user-images.githubusercontent.com/41297671/63177397-6b5ee600-c00d-11e9-89d7-e33f863fa029.png)
