### PR TITLE
[EEN-14504] Left Nav Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gem 'middleman', '~> 4.2.0'
 gem 'middleman-syntax', '~> 3.0.0'
 gem 'middleman-autoprefixer', '~> 2.10.1'
+gem "middleman-sprockets", "~> 4.1.0"
+
 gem 'rouge', '~> 2.0.5'
 gem 'redcarpet', '~> 3.4.0'
 

--- a/config.rb
+++ b/config.rb
@@ -54,7 +54,6 @@ set :file_watcher_ignore, [
         /(^|\/)\.?#/
     ]
 
-#activate :sprockets
 activate :sprockets do |c|
   c.supported_output_extensions = [".js"]
 end

--- a/config.rb
+++ b/config.rb
@@ -54,6 +54,11 @@ set :file_watcher_ignore, [
         /(^|\/)\.?#/
     ]
 
+#activate :sprockets
+activate :sprockets do |c|
+  c.supported_output_extensions = [".js"]
+end
+
 # Autoprefixer
 activate :autoprefixer do |config|
   config.browsers = ['last 2 version', 'Firefox ESR']


### PR DESCRIPTION
Newer versions of sprockets breaks our .css, but are required for .js generation.

This only activate sprockets for JS. As result we get the left-nav back.