### PR TITLE
[EEN-14648] Missing GET Fields

### DIFF
--- a/source/includes/_api_account.md
+++ b/source/includes/_api_account.md
@@ -585,7 +585,9 @@ curl -X GET https://login.eagleeyenetworks.com/g/account/list -H "Authentication
         "20180228234555.722",
         0,
         "Greater ID",
-        0
+        0,
+        {"is_sso_enabled":0, "timezone":"US/Central", "feature_flags":[]},
+        "A@GFIMLNQSUTYZcedgfhmqpsutvz"
     ],
     [...],
     [...],
@@ -616,8 +618,24 @@ Array Index | Attribute              | Data Type | Description
 16          | average_retention_days | int       | The average number of retention days for the account
 17          | customer_id            | string    | The customer ID assigned to this account
 18          | unknown_camera_count   | int       | The camera count where the status was 'invalid' (i.e. *unknown*) from all <a class="definition" onclick="openModal('DOT-EE-Archiver')">Archivers</a> <br><br>When requesting details about an <a class="definition" onclick="openModal('DOT-ESN')">ESN</a> from an Archiver they sometimes return 'invalid'. The middleware handles asking each of the Archivers for an ESN and sends back the first result that is valid
+19          | [json](#account-json)  | json      | Miscellaneous settings of the account as a Json structure
+20          | permissions            | string    | String of characters each defining a permission level of the current user
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
+
+### Account - json
+
+Parameter             | Data Type | Description
+---------             | --------- | -----------
+[json](#account-json) | string    | Miscellaneous settings of the account as a Json-formatted string
+
+### Account - json
+
+Parameter               | Data Type         | Description
+---------               | ---------         | -----------
+is_sso_enabled          | boolean           | Indicates whether single sign-on is enabled (1) or not (0)
+timezone                | string            | Timezone of the account
+feature_flags           | array[string]     | Array of strings representing the additional activated features	
 
 ### HTTP Status Codes
 

--- a/source/includes/_api_managed_switch.md
+++ b/source/includes/_api_managed_switch.md
@@ -293,6 +293,7 @@ is_detailed | boolean   | Whether to include detailed data in the response (true
 ```json
 [
     {
+    	"name": null,
         "bridges": [
             "10107f40"
         ],
@@ -366,7 +367,7 @@ is_detailed | boolean   | Whether to include detailed data in the response (true
 
 ### HTTP Response
 
-The response body will be in EEN JSON-RPC format. The payload body will return a list of switch objects containing the `'guid'`, `'state'`, `'bridges'` and `'ports'` keys. If `'is_detailed=true'`, the response will contain all of the below information:
+The response body will be in EEN JSON-RPC format. The payload body will return a list of switch objects containing the `'guid'`, `'state'`, `'bridges'`, `'name'`, `'available_bridges'` and `'ports'` keys. If `'is_detailed=true'`, the response will contain all of the below information:
 
 Parameter         | Data Type     | Description                                                                                                              | Basic Model |
 ---------         | ---------     | -----------                                                                                                              |:-----------:|
@@ -374,12 +375,12 @@ guid              | string        | Globally Unique Identifier of the switch    
 state             | string        | State of the managed switch: <br>`'REDY'` - idle and ready to control <br>`'PROB'` - probing for the data behind ports like mac/voltage/enabled etc. <br>`'CTRL'` - busy actively changing settings                                                                                      | **&check;** |
 bridges           | array[string] | List of bridge <a class="definition" onclick="openModal('DOT-ESN')">ESNs</a> this managed switch was found on            | **&check;** |
 ports             | integer       | Number of controllable PoE ports available on the switch                                                                 | **&check;** |
-name              | string        | Name of the switch                                                                                                       | **&cross;** |
+name              | string        | Name of the switch                                                                                                       | **&check;** |
+available_bridges | array[string] | List of available bridge <a class="definition" onclick="openModal('DOT-ESN')">ESNs</a>, i.e. bridges that this switch can be attached to                                                                                                                                                           | **&check;** |
 ip                | string        | IP address of managed switch                                                                                             | **&cross;** |
 version           | string        | Version information                                                                                                      | **&cross;** |
 comment           | string        | Comment stored on switch                                                                                                 | **&cross;** |
 [port_details](#managed-switch-port_details) | array[obj]    | List of *port details* objects                                                                | **&cross;** |
-available_bridges | array[string] | List of available bridge <a class="definition" onclick="openModal('DOT-ESN')">ESNs</a>, i.e. bridges that this switch can be attached to                                                                                                                                                           | **&cross;** |
 
 ### HTTP Status Codes
 

--- a/source/includes/_api_user.md
+++ b/source/includes/_api_user.md
@@ -676,7 +676,7 @@ Array Index | Attribute          | Data Type     | Description
 3           | email              | string        | Email address of the user
 4           | permissions        | array[string] | Array of strings representing user permissions
 5           | last_login         | string        | EEN timestamp of the last login by the user. Format: YYYYMMDDHHMMSS.NNN
-6           | weekly_newsletter  | json          | Json object of weekly newsletter defined in the following way: <br><br>1 - subscribed to the weekly newsletter<br>0 - not subscribed to the weekly newsletter
+6           | weekly_newsletter  | string        | Json-formatted string representing the weekly newsletter subscription defined in the following way: <br><br>1 - subscribed to the weekly newsletter<br>0 - not subscribed to the weekly newsletter
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 

--- a/source/includes/_api_user.md
+++ b/source/includes/_api_user.md
@@ -639,7 +639,10 @@ email     | string    | Email address of the user. The returned array will conta
             "user_admin",
             "active"
         ],
-        "20180929154619.000"
+        "20180929154619.000",
+        { 
+            "weekly_newsletter": 0
+        }
     ],
     [
         "ca00783b",
@@ -652,7 +655,10 @@ email     | string    | Email address of the user. The returned array will conta
             "live_video",
             "active"
         ],
-        "20180716205645.000"
+        "20180716205645.000",
+        { 
+            "weekly_newsletter": 1
+        }
     ],
     [...],
     [...],
@@ -662,14 +668,15 @@ email     | string    | Email address of the user. The returned array will conta
 
 ### HTTP Response (Array Attributes)
 
-Array Index | Attribute   | Data Type     | Description
----------   | ----------- | ---------     | -----------
-0           | id          | string        | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a>
-1           | first_name  | string        | First name of the user
-2           | last_name   | string        | Last name of the user
-3           | email       | string        | Email address of the user
-4           | permissions | array[string] | Array of strings representing user permissions
-5           | last_login  | string        | EEN timestamp of the last login by the user. Format: YYYYMMDDHHMMSS.NNN
+Array Index | Attribute          | Data Type     | Description
+---------   | ------------------ | ---------     | -----------
+0           | id                 | string        | <a class="definition" onclick="openModal('DOT-User-ID')">User ID</a>
+1           | first_name         | string        | First name of the user
+2           | last_name          | string        | Last name of the user
+3           | email              | string        | Email address of the user
+4           | permissions        | array[string] | Array of strings representing user permissions
+5           | last_login         | string        | EEN timestamp of the last login by the user. Format: YYYYMMDDHHMMSS.NNN
+6           | weekly_newsletter  | json          | Json object of weekly newsletter defined in the following way: <br><br>1 - subscribed to the weekly newsletter<br>0 - not subscribed to the weekly newsletter
 
 <aside class="success">Please note that the model definition has property keys, but that's only for reference purposes since it's just a standard array</aside>
 


### PR DESCRIPTION
### Update 1

Adding `weekly_newsletter`

`GET https://login.eagleeyenetworks.com/g/user/list`

![Screenshot from 2019-12-11 12-32-04](https://user-images.githubusercontent.com/4545188/70649223-4cb2d980-1c12-11ea-913c-cdf6b442b4b7.png)

### Update 2

`GET https://login.eagleeyenetworks.com/g/managed_switch/list`

Managed Switches:
* Added `name` and `available_bridges` to header sentences.
* Made this two fields required in description
* Added `name` to json example code

![Screenshot from 2019-12-11 15-11-53](https://user-images.githubusercontent.com/4545188/70660818-9e665e80-1c28-11ea-8614-f097e695ef27.png)

### Update 3

`GET https://login.eagleeyenetworks.com/g/account/list`

Added Miscellaneous setting & Permission string.

![Screenshot from 2019-12-11 15-13-36](https://user-images.githubusercontent.com/4545188/70661057-16cd1f80-1c29-11ea-8812-6a7d6cada428.png)

In the code example section:

![Screenshot from 2019-12-11 15-13-44](https://user-images.githubusercontent.com/4545188/70661059-1896e300-1c29-11ea-899b-82922916eb1d.png)